### PR TITLE
Removing some cordova-added boilerplate code

### DIFF
--- a/www/nativeaudio.js
+++ b/www/nativeaudio.js
@@ -1,4 +1,4 @@
-cordova.define("cordova-plugin-nativeaudio.nativeaudio", function(require, exports, module) { /*
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -65,4 +65,3 @@ module.exports  = {
         return cordova.exec(successCallback, errorCallback, "NativeAudio", "setVolumeForComplexAsset", [id, parseFloat(volume)]);
     }
 };
-});


### PR DESCRIPTION
Looks like this cordova-generated code was accidentally committed. This was causing builds to succeed, but cordova to fail during startup because the native audio plugin slug was being used twice (in the same file).